### PR TITLE
Enable or disable helper bar using the Store Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ Then add the module to the require section to ensure it gets loaded.
    }
 ```
 
-For each of the instances that you want to be displayed you need to modify `app/etc/env.php` and set the variable `HELPER_BAR` to be
-what value you want to be shown in the admin for each of the pipeline instances.
+Then navigate to Stores -> Configuration -> Advanced -> Developer -> Debug
+and select "Enabled Helper Bar for Admin": "Yes""

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
+    <system>
+        <section id="dev" translate="label" type="text" sortOrder="920" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Developer</label>
+            <tab>advanced</tab>
+            <resource>Magento_Backend::dev</resource>
+            <group id="debug" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+                <label>Debug</label>
+                <field id="helper_bar_admin" translate="label" type="select" sortOrder="22" showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Enabled Helper Bar for Admin</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+            </group>
+        </section>
+    </system>
+</config>


### PR DESCRIPTION
- Adding a new option in Store Configuration, Developer Debug Section
- The core config data option is the used to establish if the Helper Bar should be displayed or not in HelperBar.php
