### PR TITLE
MAGEP-14: Show only commands are permitted using an ACL Resource ID

### DIFF
--- a/Api/CommandInterface.php
+++ b/Api/CommandInterface.php
@@ -24,4 +24,9 @@ interface CommandInterface
      */
     public function getOptions();
 
+    /**
+     * Return the acl resource for the command
+     */
+    public function getResourceId();
+
 }

--- a/Block/Adminhtml/HelperBar.php
+++ b/Block/Adminhtml/HelperBar.php
@@ -137,6 +137,9 @@ class HelperBar extends Template
     {
         $commands = [];
         foreach ($this->commandRepository->getAllCommands() as $name => $command) {
+            if (!$this->authorization->isAllowed($command->getResourceId())) {
+                continue;
+            }
             $commands[$name] = [
                 "url" => $command->getHandlerUrl(),
                 "options" => $command->getOptions()

--- a/Model/Commands/ClearCache.php
+++ b/Model/Commands/ClearCache.php
@@ -28,6 +28,10 @@ class ClearCache implements CommandInterface
         $this->urlBuilder = $urlInterface;
     }
 
+    public function getResourceId() {
+        return 'Magento_Backend::cache';
+    }
+
     public function getName()
     {
         return 'Clear Cache';

--- a/Model/Commands/TemplatePathHints.php
+++ b/Model/Commands/TemplatePathHints.php
@@ -21,6 +21,10 @@ class TemplatePathHints implements CommandInterface
         $this->urlBuilder = $urlInterface;
     }
 
+    public function getResourceId() {
+        return 'Magento_Config::dev';
+    }
+
     /**
      * Return the name for this command
      *


### PR DESCRIPTION
- Commands must specify an ACL Resource ID
- Block validate the resource ID for each commands and only shows if the user has permission to access it
