### PR TITLE
MAGEP-14: Add environment name from config

### DIFF
--- a/Block/Adminhtml/HelperBar.php
+++ b/Block/Adminhtml/HelperBar.php
@@ -15,6 +15,8 @@ use MX\HelperBar\Api\CommandRepositoryInterface;
 
 class HelperBar extends Template
 {
+
+    const ENVIRONMENT_NAME = 'ENVIRONMENT_NAME';
     const ENV_PARAM = 'HELPER_BAR';
     const CONFIG_DATA_PATH = "dev/debug/helper_bar_admin";
     const ADMIN_RESOURCE = 'Magento_Backend::admin';
@@ -55,6 +57,11 @@ class HelperBar extends Template
     protected $commandRepository;
 
     /**
+     * @var string
+     */
+    private $environmentName;
+
+    /**
      * HelperBar constructor.
      *
      * @param Reader $reader
@@ -75,9 +82,9 @@ class HelperBar extends Template
         JsonHelper $jsonHelper,
         AuthorizationInterface $authorization,
         CommandRepositoryInterface $commandRepository,
-
         Template\Context $context,
-        array $data = []
+        array $data = [],
+        $environmentName
     )
     {
         $this->reader = $reader;
@@ -87,6 +94,7 @@ class HelperBar extends Template
         $this->jsonHelper = $jsonHelper;
         $this->authorization = $authorization;
         $this->commandRepository = $commandRepository;
+        $this->environmentName = $environmentName;
         parent::__construct($context, $data);
     }
 
@@ -118,6 +126,14 @@ class HelperBar extends Template
     {
         $env = $this->reader->load(ConfigFilePool::APP_ENV);
         return isset($env[State::PARAM_MODE]) ? $env[State::PARAM_MODE] : null;
+    }
+
+    /**
+     * Return the value of the
+     */
+    public function getEnvironmentName()
+    {
+        return ucfirst($this->environmentName) . ' ' . __("Environment");
     }
 
     /**

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <preference for="MX\HelperBar\Api\CommandRepositoryInterface" type="MX\HelperBar\Model\CommandRepository" />
+    <type name="MX\HelperBar\Block\Adminhtml\HelperBar">
+        <arguments>
+            <argument name="environmentName" xsi:type="init_parameter">MX\HelperBar\Block\Adminhtml\HelperBar::ENVIRONMENT_NAME</argument>
+        </arguments>
+    </type>
 </config>

--- a/view/adminhtml/templates/helperbar.phtml
+++ b/view/adminhtml/templates/helperbar.phtml
@@ -8,11 +8,15 @@
         <span class="mage-mode column mage-mode-<?= $block->getMode(); ?>"></span>
 
         <span class="env column white">
-            <?= $block->getProductMetadata(); ?>
+            <?= $block->getEnvironmentName(); ?>
         </span>
 
         <span class="env column">
             <input id="helper-bar-command-search">
+        </span>
+
+        <span id="product-metadata" class="env column white">
+            <?= $block->getProductMetadata(); ?>
         </span>
 
         <span id="helper-bar-close" class="helper-bar-close" title="CTRL + `">X</span>

--- a/view/adminhtml/web/helperbar.css
+++ b/view/adminhtml/web/helperbar.css
@@ -21,6 +21,10 @@
     margin-left: 10px;
 }
 
+#product-metadata {
+    margin-left: 25%;
+}
+
 .mage-mode-developer {
     background-image:url('images/Flash-Left-Developer.jpg');
     width: 225px;

--- a/view/adminhtml/web/js/helperbar.js
+++ b/view/adminhtml/web/js/helperbar.js
@@ -79,6 +79,10 @@ define([
                              });
                          }
                      }, this));
+                },
+                messages: {
+                    noResults: '',
+                    results: function() {}
                 }
             });
         },


### PR DESCRIPTION
- removing helper text on autocomplete widget as breaks layout
